### PR TITLE
Add Gemini chat API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# office-chat
+# Office Chat
+
 Office-Chat 致力于把生成式 AI 深度嵌入 Office 三大核心场景 —— 演示、表格、文档 —— 让用户通过对话即刻完成内容构思、编辑排版、智能分析与协同分享，显著降低学习门槛、提升创作与决策效率。
+
+本仓库提供一个使用 [Google Gemini](https://ai.google.dev/) 的简易聊天 API 实现。
+
+## 快速开始
+
+1. 安装依赖：
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. 设置环境变量 `GOOGLE_API_KEY` 为你的 Gemini API Key。
+3. 运行服务：
+   ```bash
+   python app.py
+   ```
+4. 发送 POST 请求到 `http://localhost:8000/chat`，请求体格式如下：
+   ```json
+   { "message": "你的问题" }
+   ```
+   服务会返回 Gemini 生成的回复。
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,32 @@
+import os
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import google.generativeai as genai
+
+api_key = os.getenv("GOOGLE_API_KEY")
+if not api_key:
+    raise RuntimeError("GOOGLE_API_KEY environment variable not set")
+
+# Configure the Gemini client
+genai.configure(api_key=api_key)
+model = genai.GenerativeModel("gemini-pro")
+
+app = FastAPI(title="Office Chat")
+
+class ChatRequest(BaseModel):
+    message: str
+
+class ChatResponse(BaseModel):
+    response: str
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest):
+    try:
+        result = model.generate_content(req.message)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return ChatResponse(response=result.text)
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("app:app", host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+google-generativeai


### PR DESCRIPTION
## Summary
- create a simple FastAPI server using Google Gemini
- document how to run it in Chinese
- include requirements file

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68831c09e7588330af78469e8ffab722